### PR TITLE
Delete global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-    "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "3.0.44"
-    }
-}


### PR DESCRIPTION
This pull request removes the `global.json` file, which previously specified the `MSBuild.Sdk.Extras` version as `3.0.44`. This change simplifies the project setup by eliminating the need for this configuration file.